### PR TITLE
cmake、gcc-c++ are dependencies, I added this two to Readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ make
 cd bin/
 ```
 # Dependence 
-glib2-devel、libpcap-devel、libnet-devel
+glib2-devel、libpcap-devel、libnet-devel 、cmake、gcc-c++
 
 # Install
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -10,7 +10,7 @@ MySQL Sniffer 是一个基于 MySQL 协议的抓包工具，实时抓取 MySQLSe
 建议在 centos6.2 及以上编译安装，并用 root 运行。
 
 ### 依赖
-glib2-devel、libpcap-devel、libnet-devel
+glib2-devel、libpcap-devel、libnet-devel 、cmake、gcc-c++
 
 ### 安装
 ```


### PR DESCRIPTION
Readme的里面写的依赖包列表不全，其实cmake、gcc-c++ 也是编译时需要的，否则会报错