### PR TITLE
append libpthread.so.0  to file CMakeLists.txt

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -31,6 +31,7 @@ EXECUTE_PROCESS(COMMAND make
 ADD_EXECUTABLE(mysql-sniffer ${SRC_LIST})
 TARGET_LINK_LIBRARIES(mysql-sniffer optimized
     libnidstcpreasm.a
+    libpthread.so.0
     libnet.a 
     libpcap.a
     libglib-2.0.a 
@@ -39,6 +40,7 @@ TARGET_LINK_LIBRARIES(mysql-sniffer optimized
    
 TARGET_LINK_LIBRARIES(mysql-sniffer debug
     libnidstcpreasm-dbg.a
+    libpthread.so.0
     libnet.a 
     libpcap.a
     libglib-2.0.a


### PR DESCRIPTION
without libpthread.so.0,it will throw error when executing make:

/bin/ld: /home/xxx/mysql-sniffer/lib/libgthread-2.0.a(gthread-impl.o): undefined reference to symbol 'pthread_join@@GLIBC_2.2.5'
//usr/lib64/libpthread.so.0: 无法添加符号: DSO missing from command line
collect2: 错误：ld 返回 1
make[2]: *** [bin/CMakeFiles/mysql-sniffer.dir/build.make:159：bin/mysql-sniffer] 错误 1
make[1]: *** [CMakeFiles/Makefile2:86：bin/CMakeFiles/mysql-sniffer.dir/all] 错误 2
make: *** [Makefile:84：all] 错误 2